### PR TITLE
Avoid creating unwanted duplicate utxos when the bitcoin node is busy

### DIFF
--- a/ts_src/index.ts
+++ b/ts_src/index.ts
@@ -204,28 +204,40 @@ function _faucetMaker(
       new Promise((resolve): number => setTimeout(resolve, ms));
     const randInt = (min: number, max: number): number =>
       min + Math.floor((max - min + 1) * Math.random());
+    const txId = await _requester(address, value).then(
+      v => v, // Pass success value as is
+      async err => {
+        // Bad Request error is fixed by making sure height is >= 432
+        const currentHeight = (await self.height()) as number;
+        if (err.message === 'Bad Request' && currentHeight < 432) {
+          await self.mine(432 - currentHeight);
+          return _requester(address, value);
+        } else if (err.message === 'Bad Request' && currentHeight >= 432) {
+          return _requester(address, value);
+        } else {
+          throw err;
+        }
+      },
+    );
     while (_unspents.length === 0) {
       if (count > 0) {
-        if (count >= 5) throw new Error('Missing Inputs');
+        if (count >= 5) {
+          // Sometimes indexd takes more than 60 secs to sync.
+          console.log('WARNING: Indexd is busy. Using getrawtransaction RPC.');
+          const tx = await self.fetch(txId);
+          const outs = tx.outs.filter(x => x.address === address);
+          const out = outs.pop();
+          if (out) {
+            const vout = tx.outs.indexOf(out);
+            const v = out.value;
+            return { txId, vout, value: v };
+          } else {
+            throw new Error('Missing Inputs');
+          }
+        }
         console.log('Missing Inputs, retry #' + count);
         await sleep(randInt(150, 250));
       }
-
-      const txId = await _requester(address, value).then(
-        v => v, // Pass success value as is
-        async err => {
-          // Bad Request error is fixed by making sure height is >= 432
-          const currentHeight = (await self.height()) as number;
-          if (err.message === 'Bad Request' && currentHeight < 432) {
-            await self.mine(432 - currentHeight);
-            return _requester(address, value);
-          } else if (err.message === 'Bad Request' && currentHeight >= 432) {
-            return _requester(address, value);
-          } else {
-            throw err;
-          }
-        },
-      );
 
       await sleep(randInt(50, 150));
 


### PR DESCRIPTION
Avoid creating unwanted duplicate (additional) utxos when the bitcoin node is busy (after some more thought I think it's indexd that's catching up).

Move the tx creator out of the loop so no new utxos are created when in case `unspents` fetching needs to be retried.
Fixes https://github.com/bitcoinjs/regtest-client/issues/3