### PR TITLE
Fixes npm install. Installs correct version of bitcoinjs-lib.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@types/node": "^11.13.0",
     "@types/randombytes": "^2.0.0",
-    "bitcoinjs-lib": "git+https://github.com/bitcoinjs/bitcoinjs-lib.git#8bbe7c7178f8f7d0cdbed13da13a6e62dacb3d06",
+    "bitcoinjs-lib": "^5.2.0",
     "mocha": "^6.1.4",
     "prettier": "^1.16.4",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
npm install fails (on macos at least) because of some dependencies on bitcoinjs-lib.

Since tests were built using bitcoinjs-lib 5, update package.json to use the latest possible version of the 5. branch.